### PR TITLE
Example in the readme.md updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ grunt.initConfig({
   svgstore: {
     options: {
       prefix : 'icon-', // This will prefix each ID
-      svg: { // will be added as attributes to the resulting SVG
-        viewBox : '0 0 100 100'
+      svg: { // will add and overide the the default xmlns="http://www.w3.org/2000/svg" attribute to the resulting SVG
+        viewBox : '0 0 100 100',
+        xmlns: 'http://www.w3.org/2000/svg'
       }
     },
     your_target: {


### PR DESCRIPTION
The readme.md demo in the previous state removed the ability to link external svgs it removed the `xmlns` property not just adding the `"viewBox"`
