### PR TITLE
A way to generate fixed sized reference based copies of symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ Default value: `false`
 
 When set to false, no cleanup is performed on the `<defs>` element.
 
+#### options.fixedSizeVersion
+Type: `Object` or `boolean`
+Default value: `false`
+
+When `true` or a configuration object is passed for each of the symbols another one, with suffixed id generated.
+All those additional symbols have the common dimensions and refers to the original symbols with `<use>`.
+Original symbols are placed exactly in the middle of the fixed-size viewBox of the fixed size version.
+
+Configuration reference and default values if `true` is passed:
+```js
+grunt.initConfig({
+  svgstore: {
+    options: {
+      fixedSizeVersion: {
+        width: 50,
+        height: 50,
+        suffix: '-fixed-size',
+        maxDigits: {
+          translation: 4,
+          scale: 4,
+        },
+      },
+    },
+  },
+});
+```
+
+Any of the configuration object properties may be omitted.
+
 
 
 ### Usage Examples


### PR DESCRIPTION
Rationale:

In a project where I use svgstore I have most of my icons in one size: 25x25px, centered.
Some subset of icons are used another way as well in their original dimensions (let's say the icon is rectangular, not square). The changes I suggest allow to create 2 symbols from one source SVG file:
one with the original `viewBox` and another one, using the first one internally, with fixed `viewBox` and the original symbol entered in it.

This way one mustn't export 2 SVG files: one in the fixed viewBox for general use and another, with viewBox adapted to the actual content of the SVG file.

If you find this feature useful I'll write the unit tests.  
