### PR TITLE
Adds the preserving of  for strokes (in addition to fills)

### DIFF
--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -146,7 +146,7 @@ module.exports = function (grunt) {
 
           Object.keys(attrs).forEach(function (key) {
             var value = attrs[key];
-            var id, match, preservedKey = '';
+            var id, match, isFillCurrentColor, isStrokeCurrentColor, preservedKey = '';
 
             while ( (match = urlPattern.exec(value)) !== null){
               id = match[1];
@@ -177,6 +177,9 @@ module.exports = function (grunt) {
 
                 if (cleanupAttributes.indexOf(key) > -1 || cleanupAttributes.indexOf(preservedKey) > -1){
 
+                  isFillCurrentColor = key === 'fill' && $elem.attr('fill') === 'currentColor';
+                  isStrokeCurrentColor = key === 'stroke' && $elem.attr('stroke') === 'currentColor';
+
                   if (preservedKey && preservedKey.length) {
                     //Add the new key preserving value
                     $elem.attr(preservedKey, $elem.attr(key));
@@ -184,9 +187,9 @@ module.exports = function (grunt) {
                     //Remove the old preserve--foo key
                     $elem.removeAttr(key);
                   }
-                  else if (!(key === 'fill' && $elem.attr('fill') === 'currentColor')) {
+                  else if (!(isFillCurrentColor || isStrokeCurrentColor)) {
                     // Letting fill inherit the `currentColor` allows shared inline defs to
-                    // be styled differently based on an xlink element's `color` so we leave these
+                    // be styled differently based on an SVG element's `color` so we leave these
                     $elem.removeAttr(key);
                   }
                 } else {


### PR DESCRIPTION
@FWeinb  This PR adds to currently existing behavior where `currentColor` is preserved for fills (I added this probably a year ago :yum: ), even if the clean array contains `fill`. Specifically, this PR also checks and preserves `stroke`. 

Below you see I'm adding a stroke color from `use` element to achieve a second color.
<img width="111" alt="screen shot 2015-11-04 at 3 18 52 pm" src="https://cloud.githubusercontent.com/assets/142403/10955425/8ca0fa10-8308-11e5-8fa8-d98ecce50225.png">

I ran `grunt` and tests passed locally

The reason we're exploring strokes at all, is that we currently control our svg icon sizes via CSS class like `icon-large`, `icon-small`, etc. What happens, is that the stroke ends up scaling in an undesirable way where we'd prefer to have the option of having it not scale. Also, it'd be nice to actually be able to leave strokes as strokes on export from the vector program ex. AI (right now we compound path everything). To achieve the "no scale" we're going to utilize Chris's idea here: http://codepen.io/chriscoyier/pen/dIlep essentially:
```css
.no-scale {
  vector-effect: non-scaling-stroke;
}
```