### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "chalk": "^0.4.0",
-    "cheerio": "^0.18.0",
+    "cheerio": "^0.19.0",
     "js-beautify": "^1.5.1",
     "multiline": "^0.3.4",
     "handlebars": "^2.0.0"


### PR DESCRIPTION
Update cheerio to 0.19.0 to avoid npm install deprication warnings.