### PR TITLE
fixedSizeVersion: reference the original svg

### DIFF
--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -325,7 +325,7 @@ module.exports = function (grunt) {
 
           $symbolFixed
             .find('use')
-            .attr('xlink:href', '#' + fixedId)
+            .attr('xlink:href', '#' + graphicId)
             .attr('transform', [
               'scale(' + parseFloat(scale.toFixed(options.fixedSizeVersion.maxDigits.scale || 4)).toPrecision() + ')',
               'translate(' + [


### PR DESCRIPTION
Changes the `<use>` element to reference the original svg instead of the fixed size svg in a loop (which crashes the tab in Chrome).