### PR TITLE
Lock JS Beautify at 1.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "chalk": "^0.4.0",
     "cheerio": "^0.18.0",
-    "js-beautify": "^1.5.1",
+    "js-beautify": "~1.5.10",
     "multiline": "^0.3.4",
     "handlebars": "^2.0.0"
   },


### PR DESCRIPTION
There’s an issue right now with `js-beautify` v1.6 where internal SVG elements are no longer being indented. This also results in failed Travis tests. Locking the version at the latest 1.5.x branch resolves this issue.