### PR TITLE
Enable usage of svg sprite as .CSS{ backgorund-image: ('shapes.svg#my-svg-id'); }

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ grunt.initConfig({
   },
 });
 ```
+### Use as CSS background:
+
+```css
+.css {
+  background-image: url('dest/dest.svg#filename')
+}
+});
+```
 
 #### options.includeTitleElement (since 0.5.0)
 Type: `Boolean`

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ grunt.initConfig({
 .css {
   background-image: url('dest/dest.svg#filename')
 }
-});
 ```
 
 #### options.includeTitleElement (since 0.5.0)

--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -97,6 +97,8 @@ module.exports = function (grunt) {
         $resultSvg.attr(attr, options.svg[attr]);
       }
 
+      $resultSvg.append('<style>svg.sprite-svg{display:none}svg.sprite-svg:target{display:block}</style>');
+
       file.src.filter(function (filepath) {
         if (!grunt.file.exists(filepath)) {
           grunt.log.warn('File "' + filepath + '" not found.');
@@ -238,8 +240,8 @@ module.exports = function (grunt) {
         title = title || id;
 
         // Generate symbol
-        var $res = cheerio.load('<symbol>' + $svg.html() + '</symbol>', { xmlMode: true });
-        var $symbol = $res('symbol').first();
+        var $res = cheerio.load('<svg>' + $svg.html() + '</svg>', { xmlMode: true });
+        var $symbol = $res('svg').first();
 
         // Merge in symbol attributes from option
         for (var attr in options.symbol) {


### PR DESCRIPTION
- "symbol" tag replaced with "svg"
- added inline style in destination file <style>svg.sprite-svg{display:none}svg.sprite-svg:target{display:block}</style>
- This changes allow to use svg sprite as css background image like this:
  .my-css {
  background-image: url('../svg/shapes.svg#my-svg-id');
  }

shapes.svg must be valid XML

Examples:
http://prototypes.magicsolutions.bg/svg-test/shapes.svg#svg-cloths-icon
http://prototypes.magicsolutions.bg/svg-test/shapes.svg#svg-cleaning-icon
