### PR TITLE
Fixed only checking 'viewBox', and not 'viewbox' on source items

### DIFF
--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -258,6 +258,11 @@ module.exports = function (grunt) {
         // Add viewBox (if present on SVG w/ optional width/height fallback)
         var viewBox = $svg.attr('viewBox');
 
+        // In case the user didn't use proper caps, but all lower-case.
+        if (!viewBox && $svg.attr('viewbox')) {
+            viewBox = $svg.attr('viewbox');
+        }
+
         if (!viewBox && options.inheritviewbox) {
           var width = $svg.attr('width');
           var height = $svg.attr('height');


### PR DESCRIPTION
It took me about an hour to figure out why my icons weren't sizing properly. This small fix should take care of that.

Basically, the old code only checked for a `viewBox` element. Making the following result in a viewBox-less symbol:

```svg
<?xml version="1.0" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 22 16">
  <polyline fill="none" stroke-width="2" points="1 7 8 14 21 1"/>
</svg>
```

I'd love to make some unit tests for this, but sadly can't get my head around the unit test system at the moment (maybe because it's Friday afternoon).