### PR TITLE
Bump grunt jshint to fix error that halts grunt task execution comple…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "grunt": "~0.4.5",
     "html-minifier": "~0.6.8",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "^0.12.0",
     "grunt-contrib-nodeunit": "~0.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
I elected to do this on its own branch to keep my last PR single responsibility .. but the issue is when you run just `grunt` the `jshint` grunt task gives:

![image](https://user-images.githubusercontent.com/142403/32389954-bd34a8e6-c089-11e7-9728-ee6c151a3f4f.png)

(I'm on a recent macbook if that matters).

As I know a bit about grunt, I was able to dev by doing `grunt test` directly, but, this will definitely trip up junior dev contributors.

With some googling I found folks saying to just upgrade:
https://github.com/fians/Waves/issues/164

And that in fact fixed the issue for me after of course running `npm install` to get updated.