### PR TITLE
Implement option to skip svg files with duplicate filenames

### DIFF
--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -125,10 +125,9 @@ module.exports = function (grunt) {
 
         // Skip duplicated svg files
         if (options.removeDuplicateSVGs) {
-          duplicateID = allSvgIds.includes(id) ? true : false;
+          duplicateID = allSvgIds.includes(id);
           allSvgIds.push(id);
-  
-          if (duplicateID){
+          if (duplicateID) {
             grunt.log.writeln('duplicate filename ' + id + ' was skipped');
             return false;
           }

--- a/tasks/svgstore.js
+++ b/tasks/svgstore.js
@@ -71,6 +71,7 @@ module.exports = function (grunt) {
       removeEmptyGroupElements: true,
       removeWithId: null,
       setUniqueIds: true,
+      removeDuplicateSVGs: true,
       svg: {
         'xmlns': 'http://www.w3.org/2000/svg'
       },
@@ -86,6 +87,10 @@ module.exports = function (grunt) {
     }
 
     this.files.forEach(function (file) {
+      if (options.removeDuplicateSVGs) {
+        var allSvgIds = [];
+        var duplicateID = false;
+      }
       var $resultDocument = cheerio.load('<svg><defs></defs></svg>', { xmlMode: true });
 
       var $resultSvg = $resultDocument('svg');
@@ -117,6 +122,17 @@ module.exports = function (grunt) {
           normalizeWhitespace: true,
           xmlMode: true
         });
+
+        // Skip duplicated svg files
+        if (options.removeDuplicateSVGs) {
+          duplicateID = allSvgIds.includes(id) ? true : false;
+          allSvgIds.push(id);
+  
+          if (duplicateID){
+            grunt.log.writeln('duplicate filename ' + id + ' was skipped');
+            return false;
+          }
+        }
 
         // Remove empty g elements
         if (options.removeEmptyGroupElements) {


### PR DESCRIPTION
I needed this option for a big-scale project where different clients can overwrite single icons by using the existing svg filename, but uploading it to a client specific directory. 
The implementation may be too simple and I didn't write any tests, but if you could use this branch as a base and implement the option, it'll be great.
Please note that I use `id` instead of `filename`. This is needed due to Rails naming conventions (we have files like `close.de_xy.svg`, which overwrites `close.svg`)